### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,6 @@ overrides default options.
 Please find the list of current defaults in
 [cors_plug.ex](lib/cors_plug.ex#L5:L26).
 
-**As per the [W3C Recommendation](https://www.w3.org/TR/cors/#access-control-allow-origin-response-header)
-the string `null` is returned when no configured origin matched the request.**
-
 
 ## License
 


### PR DESCRIPTION
The plug no longer returns the string null, as of commit fb12d5da7354762128053d0a5faf4870bcfb1334.